### PR TITLE
Add restProps to anchor

### DIFF
--- a/src/Link.js
+++ b/src/Link.js
@@ -20,6 +20,7 @@ class LinkWithNavigation extends Component {
       routeKey,
       navigation,
       action,
+      ...restProps,
     } = this.props;
     const topNavigation = getTopNavigation(navigation);
     const topRouter = topNavigation.router;
@@ -62,6 +63,7 @@ class LinkWithNavigation extends Component {
           navigation.dispatch(navAction);
           e.preventDefault();
         }}
+        {...restProps}
       >
         {children}
       </a>


### PR DESCRIPTION
The user is able to provide `style`, `onClick` and `className` parameters  for example when creating a `Link` from `react-navigation-web`.

`restProps` is meant to contain all props that are not already extracted from `this.props` that allow the user to choose wether he want to add `className`, `onClick`, `style` for any reason.

Use case example :
~~~javascript
import React, { Component } from 'react'
import { Link } from '@react-navigation/web'

class example extends Component {
  render() {
    return (
      <Link
        className="my-classname"
        routeName="MyPage"
        style={{ anyStyleProperty: 'anyValue' }}
      >
        <span>Some text</span>
      </Link>
    )
  }
}

export default example
~~~