### PR TITLE
only set document title if truthy value provided

### DIFF
--- a/src/createBrowserApp.js
+++ b/src/createBrowserApp.js
@@ -101,6 +101,7 @@ export default function createBrowserApp(App) {
     }
     _dispatch = action => {
       const lastState = this.state.nav;
+      const onNavigationStateChange = this.props.onNavigationStateChange;
       const newState = App.router.getStateForAction(action, lastState);
       const dispatchEvents = () =>
         this._actionEventSubscribers.forEach(subscriber =>
@@ -121,6 +122,9 @@ export default function createBrowserApp(App) {
           !matchPathAndParams(pathAndParams, currentPathAndParams)
         ) {
           currentPathAndParams = pathAndParams;
+          if (onNavigationStateChange) {
+            onNavigationStateChange(lastState, newState, action);
+          }
           history.push(
             `/${pathAndParams.path}?${queryString.stringify(
               pathAndParams.params


### PR DESCRIPTION
That's say html template already provides document.title. 

If user just want to use the document.title defined in the html template, he can choose not to set `opts.title` or `opts.headerTitle`. The current implementation will set `undefined` as document title.
