### PR TITLE
only set document.title if truthy value provided

### DIFF
--- a/src/createBrowserApp.js
+++ b/src/createBrowserApp.js
@@ -82,7 +82,9 @@ export default function createBrowserApp(App) {
       const activeNav = this._navigation.getChildNavigation(childKey);
       const opts = App.router.getScreenOptions(activeNav);
       this._title = opts.title || opts.headerTitle;
-      document.title = this._title;
+      if (this._title) {
+        document.title = this._title;
+      }
     }
     render() {
       this._navigation = getNavigation(


### PR DESCRIPTION
If html template already set `document.title` and user just want to use the `document.title` defined in the html template, he can choose not to set `opts.title` or `opts.headerTitle`. 

Current implementation will set `undefined` as document title.

@ericvicenti really appreciate to have to take a look at this PR, thanks!
