### PR TITLE
Rename _dispatch to dispatch for API consistency

### DIFF
--- a/src/createBrowserApp.js
+++ b/src/createBrowserApp.js
@@ -62,7 +62,7 @@ export default function createBrowserApp(App) {
     _title = document.title;
     _actionEventSubscribers = new Set();
     componentDidMount() {
-      setHistoryListener(this._dispatch);
+      setHistoryListener(this.dispatch);
       this.updateTitle();
       this._actionEventSubscribers.forEach(subscriber =>
         subscriber({
@@ -88,7 +88,7 @@ export default function createBrowserApp(App) {
       this._navigation = getNavigation(
         App.router,
         this.state.nav,
-        this._dispatch,
+        this.dispatch,
         this._actionEventSubscribers,
         () => this.props.screenProps,
         () => this._navigation
@@ -99,7 +99,7 @@ export default function createBrowserApp(App) {
         </NavigationProvider>
       );
     }
-    _dispatch = action => {
+    dispatch = action => {
       const lastState = this.state.nav;
       const newState = App.router.getStateForAction(action, lastState);
       const dispatchEvents = () =>


### PR DESCRIPTION
When navigating without the navigation props, according to the [docs](https://reactnavigation.org/docs/en/navigating-without-navigation-prop.html) the navigator reference has a method `dispatch`.

In the `createAppContainer` method of `react-navigation-native` [exists](https://github.com/react-navigation/react-navigation-native/blob/master/src/createAppContainer.js#L316), but in `react-navigation-web` the method is called `_dispatch`.

One way to solve it is using the `Platform` component of react-native/react-native-web like:

```javascript
const action = NavigationActions.navigate({ routeName, params });

if (Platform.OS === "web") {
  navigatorRef._dispatch(action);
} else {
  navigatorRef.dispatch(action);
}
```

This PR attempts to maintain consistency between the navigator API and the docs.